### PR TITLE
Add bower.json to indicate the entry point file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "vega-wmf-loader",
+  "description": "Wrapper for loading vega with the custom WMF protocols",
+  "main": "index.js",
+  "authors": [
+    "Yuri Astrakhan <yurik@wikimedia.org>"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
`wiredep` build tool reads `bower.json`, particularly the `"main"` entry point
